### PR TITLE
Bugfix for NPE on dimension load with other chunkloaders

### DIFF
--- a/src/codechicken/chunkloader/ChunkLoaderManager.java
+++ b/src/codechicken/chunkloader/ChunkLoaderManager.java
@@ -634,6 +634,11 @@ public class ChunkLoaderManager
     }
 
     private static ChunkLoaderOrganiser getOrganiser(IChickenChunkLoader loader) {
+    	// Added bugfix here because IChickenChunkLoad.getWorld() is needed to get the WorldServer object for load(),
+    	// and this method has the last reference to the loader
+    	if(!loaded)
+    		ChunkLoaderManager.load(DimensionManager.getWorld(CommonUtils.getDimension(loader.getWorld())));
+        
         String owner = loader.getOwner();
         return owner == null ? getModOrganiser(loader.getMod()) : getPlayerOrganiser(owner);
     }
@@ -656,7 +661,10 @@ public class ChunkLoaderManager
     }
 
     private static PlayerOrganiser getPlayerOrganiser(String username) {
-        PlayerOrganiser organiser = playerOrganisers.get(username);
+        // NPE was here. The newly added activate() method in TileChunkLoaderBase will get here before the chunk manager is loaded
+    	// if another mod that loads chunks calls it first (Extra Utilities in my case).
+    	// If that happens the playerOrganisers HashMap won't be initialized yet.
+    	PlayerOrganiser organiser = playerOrganisers.get(username);
         if (organiser == null)
             playerOrganisers.put(username, organiser = new PlayerOrganiser(username));
         return organiser;


### PR DESCRIPTION
Fixes Issues 

The getPlayerOrganiser method references the playerOrganisers hashmap without checking to see if it is null. It will be null if the activate() method of TileChunkLoader base is called by another chunkloading mod before the chunk manager is loaded. A simple null check won't work in this case, so I check the loaded flag and, if false, call the load() method to initialize the chunk manager before referencing the HashMap.

My server was crashing while loading the deep dark dimension. One of my players had placed an Extra Utilities Ender Quarry there with a ChickenChunk loader next to it. Why, I don't know, because the Ender Quarry has a chunkloader already. Anyway, next time I restarted the server crashed with this stack trace. After patching and updating the plugin it started just fine with no issues.

java.lang.NullPointerException: Exception getting block type in world
    at codechicken.chunkloader.ChunkLoaderManager.getPlayerOrganiser(ChunkLoaderManager.java:659)
    at codechicken.chunkloader.ChunkLoaderManager.getOrganiser(ChunkLoaderManager.java:638)
    at codechicken.chunkloader.ChunkLoaderManager.addChunkLoader(ChunkLoaderManager.java:629)
    at codechicken.chunkloader.TileChunkLoaderBase.activate(TileChunkLoaderBase.java:108)
    at codechicken.chunkloader.TileChunkLoader.activate(TileChunkLoader.java:114)
    at codechicken.chunkloader.TileChunkLoaderBase.func_145829_t(TileChunkLoaderBase.java:35)
    at net.minecraft.world.chunk.Chunk.func_150812_a(Chunk.java:975)
...
