### PR TITLE
Escape newlines in mcmod.info

### DIFF
--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -2,11 +2,7 @@
 {
   "modid": "ChickenChunks",
   "name": "ChickenChunks",
-  "description": "Advanced chunkloading management
-
-Credits: Sanguine - Texture
-
-Supporters:",
+  "description": "Advanced chunkloading management\n\nCredits: Sanguine - Texture\n\nSupporters:",
   "version": "${version}",
   "mcversion": "${mc_version}",
   "url": "http://www.minecraftforum.net/topic/909223",


### PR DESCRIPTION
Escaped newlines in mod description, as unescaped newlines aren't valid in JSON strings